### PR TITLE
use globby to resolve source files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through = require('through2');
-var glob = require('glob');
+var globby = require('globby');
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
 var purify = require('purify-css');
@@ -7,11 +7,7 @@ var purify = require('purify-css');
 const PLUGIN_NAME = 'gulp-purifycss';
 
 module.exports = function(source, options) {
-  var sourceFiles = [];
-  source.forEach(function(pathPattern) {
-    var files = glob.sync(pathPattern);
-    sourceFiles = sourceFiles.concat(files);
-  });
+  var sourceFiles = globby.sync(source);
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-purifycss",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Remove unnecessary css",
   "main": "index.js",
   "scripts": {
@@ -21,12 +21,11 @@
     "url": "https://github.com/purifycss/gulp-purifycss/issues"
   },
   "homepage": "https://github.com/purifycss/gulp-purifycss",
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "dependencies": {
-    "glob": "^5.0.10",
-    "through2": "^2.0.0",
+    "globby": "^2.1.0",
     "gulp-util": "^3.0.5",
-    "purify-css": "^1.0.8"
+    "purify-css": "^1.0.8",
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
Then we can hand gulp-purifycss an array of globs and negations like we do with `gulp.src`.

I ran into this because I was handing gulp-purifycss an array of values like this:

```
[
  'app/**/*.{js,html}',
  '!app/bower_components/**/*.{js,html}',
  '!app/**/*.spec.js'
]
```

And the negation wasn't working like it usually does with `gulp.src`, for example. So I looked into it and globby seemed to be the simplest way to achieve what I wanted.

My editor seems to have alphabetized the package.json file - the only changes there are to replace `glob` with `globby` and to bump the version to 0.2.1.
