### PR TITLE
updated readme to include options sections and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Clean unnecessary CSS with [PurifyCSS](https://github.com/purifycss/purifycss)
 </tr>
 </table>
 
+## Options
+The (optional) `options` argument
+
+Type: `Object`
+
+Properties of options object:
+
+`minify:` Set to `true` to minify. Default: `false`.
+
+`output:` Filepath to write purified CSS to. Returns raw string if `false`. Default: `false`.
+
+`info:` Logs info on how much CSS was removed if `true`. Default: `false`.
+
+`rejected:` Logs the CSS rules that were removed if `true`. Default: `false`.
+
+`whitelist:` Array of selectors to always leave in. Ex. `['button-active', '*modal*']`` this will leave any selector that includes `modal` in it and selectors that match `button-active`. (wrapping the string with *'s, leaves all selectors that include it)
+
 ## Usage
 
 ```js
@@ -25,7 +42,7 @@ var purify = require('gulp-purifycss');
 
 gulp.task('css', function() {
   return gulp.src('./public/app/example.css')
-    .pipe(purify(['./public/app/**/*.js', './public/**/*.html']))
+    .pipe(purify(['./public/app/**/*.js', './public/**/*.html'], {options}))
     .pipe(gulp.dest('./dist/'));
 });
 ```


### PR DESCRIPTION
I made the readme a little more verbose when it comes to specifying all the options that are available to purifycss.

I took the verbiage from the purifycss readme and updated the example usage in the readme.