### PR TITLE
replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var through = require('through2');
 var glob = require('glob');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var purify = require('purify-css');
 
 const PLUGIN_NAME = 'gulp-purifycss';

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "url": "https://github.com/purifycss/gulp-purifycss/issues"
   },
   "homepage": "https://github.com/purifycss/gulp-purifycss",
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "dependencies": {
     "glob": "^5.0.10",
-    "through2": "^2.0.0",
-    "gulp-util": "^3.0.5",
-    "purify-css": "^1.0.8"
+    "plugin-error": "^1.0.1",
+    "purify-css": "^1.0.8",
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hi,
Gulp-util is depreacted and should be replaced by equivalent package according to https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

Only `plugin-error` package is needed in this library.

Cheers
midzer